### PR TITLE
use #numberOfItems and #getItem

### DIFF
--- a/svgparser.js
+++ b/svgparser.js
@@ -473,11 +473,9 @@
 		switch(element.tagName){
 			case 'polygon':
 			case 'polyline':
-				for(i=0; i<element.points.length; i++){
-					poly.push({
-						x: element.points[i].x,
-						y: element.points[i].y
-					});
+				for(i=0; i<element.points.numberOfItems; i++){
+					var point = element.points.getItem(i);
+					poly.push({ x: point.x, y: point.y });
 				}
 			break;
 			case 'rect':


### PR DESCRIPTION
I was trying to get this to work locally using Safari and found that certain SVG shapes were not showing up in the set of paths that SVGnest was trying to fit. I narrowed it down to `SvgParser.prototype.polygonify`. It was unable to iterate over the list of points because the `length` property was undefined in Safari.

I did not test this fix in other browsers. However, `numberOfItems` and `getItem` are used elsewhere in `SvgParser` successfully.