### PR TITLE
Make exports more compatible

### DIFF
--- a/svgnest.js
+++ b/svgnest.js
@@ -5,7 +5,7 @@
  
 (function(root){
 	'use strict';
-	
+
 	root.SvgNest = new SvgNest();
 	
 	function SvgNest(){
@@ -985,4 +985,4 @@
 		return pop[0];
 	}
 	
-})(this);
+})(window);

--- a/svgparser.js
+++ b/svgparser.js
@@ -700,4 +700,4 @@
 		polygonify: parser.polygonify.bind(parser)
 	};
 	
-}(this));
+}(window));

--- a/util/geometryutil.js
+++ b/util/geometryutil.js
@@ -1888,4 +1888,4 @@
 			return rotated;
 		}
 	};
-}(this));
+})(typeof window !== 'undefined' ? window : self);

--- a/util/matrix.js
+++ b/util/matrix.js
@@ -8,6 +8,7 @@ function Matrix() {
   this.queue = [];   // list of matrixes to apply
   this.cache = null; // combined matrix cache
 }
+(typeof window !== 'undefined' ? window : self).Matrix = Matrix;
 
 // combine 2 matrixes
 // m1, m2 - [a, b, c, d, e, g]

--- a/util/parallel.js
+++ b/util/parallel.js
@@ -1,12 +1,12 @@
-﻿(function () {
+﻿(function (root) {
 	var isCommonJS = typeof module !== 'undefined' && module.exports;
-	var isNode = !(typeof window !== 'undefined' && this === window);
+	var isNode = !(typeof window !== 'undefined' && root === window);
 	var setImmediate = setImmediate || function (cb) {
 		setTimeout(cb, 0);
 	};
-	var Worker = isNode ? require(__dirname + '/Worker.js') : self.Worker;
-	var URL = typeof self !== 'undefined' ? (self.URL ? self.URL : self.webkitURL) : null;
-	var _supports = (isNode || self.Worker) ? true : false; // node always supports parallel
+	var Worker = isNode ? require(__dirname + '/Worker.js') : root.Worker;
+	var URL = typeof root !== 'undefined' ? (root.URL ? root.URL : root.webkitURL) : null;
+	var _supports = (isNode || root.Worker) ? true : false; // node always supports parallel
 
 	function extend(from, to) {
 		if (!to) to = {};
@@ -382,9 +382,5 @@
 		return this;
 	};
 
-	if (isCommonJS) {
-		module.exports = Parallel;
-	} else {
-		self.Parallel = Parallel;
-	}
-})();
+	root.Parallel = Parallel;
+})(typeof window !== 'undefined' ? window : self);

--- a/util/placementworker.js
+++ b/util/placementworker.js
@@ -289,6 +289,7 @@ function PlacementWorker(binPolygon, paths, ids, rotations, config, nfpCache){
 	};
 
 }
+(typeof window !== 'undefined' ? window : self).PlacementWorker = PlacementWorker;
 
 // clipperjs uses alerts for warnings
 function alert(message) { 


### PR DESCRIPTION
When using Webpack with script-loader to, 'this' is not set to window.
Since 'this' is context dependent as part of method calls, prefer
to use 'self' when window is not available (running in web Worker)

This is the minimum needed to import SVGnest in a project that uses Webpack and use the API