### PR TITLE
ApplyTranform updates for performance and wider usability

### DIFF
--- a/svgparser.js
+++ b/svgparser.js
@@ -14,7 +14,7 @@
 		// the top level SVG element of the SVG document
 		this.svgRoot;
 		
-		this.allowedElements = ['svg','circle','ellipse','path','polygon','polyline','rect'];
+		this.allowedElements = ['svg','circle','ellipse','path','polygon','polyline','rect', 'line'];
 				
 		this.conf = {
 			tolerance: 2, // max bound for bezier->line segment conversion, in native SVG units


### PR DESCRIPTION
-For certain elements (most notably "path"), modify approach to build new "d" attribute string as code iterates through the points on the element, rather than storing the new point in s.x and s.y. This is because the overloaded setter "=" for s.x and s.y in the pathsegpolyfill utility is very expensive and leads to massive slowdown on large/complex paths.

-Support transformations for clipPath tags (including those defined within "def" tags)
-Support preservation of ids and classes through transformation
-Support transformations for line elements