### PR TITLE
First interval size is less than the following

### DIFF
--- a/svgnest.js
+++ b/svgnest.js
@@ -971,15 +971,15 @@
 		
 		var lower = 0;
 		var weight = 1/pop.length;
-		var upper = weight;
+		var upper = weight * 2;
 		
 		for(var i=0; i<pop.length; i++){
 			// if the random number falls between lower and upper bounds, select this individual
-			if(rand > lower && rand < upper){
+			if(rand >= lower && rand < upper){
 				return pop[i];
 			}
 			lower = upper;
-			upper += 2*weight * ((pop.length-i)/pop.length);
+			upper += 2*weight * ((pop.length-i-1)/pop.length);
 		}
 		
 		return pop[0];


### PR DESCRIPTION
If we have a population of 10, the first interval will be ]0, 0.1[ (size: 0.1). The second one will be ]0.1, 0.3[ (size: 0.2), greater than the first, the third one will be ]0.3, 0.48[ (size: 0.18)...

```
weigth = 1/10 = 0.1

i = 0
2*weight * ((pop.length-i)/pop.length) = 2 * 0.1 * ((10-0)/10) = 2 * 0.1 * 10/10 = 0.2

i = 1
2*weight * ((pop.length-i)/pop.length) = 2 * 0.1 * ((10-1)/10) = 2 * 0.1 * 9/10 = 0.18
```

So the first individual has less chances to be selected than the following.

And Math.random() returns a float in the [0, 1[ interval, so 0 can be returned but will never be picked because of the condition:

`rand > lower && rand < upper`

So we need to replace it by:

`rand >= lower && rand < upper`