### PR TITLE
Swap rotation while swapping placement

### DIFF
--- a/svgnest.js
+++ b/svgnest.js
@@ -881,6 +881,10 @@
 					var temp = clone.placement[i];
 					clone.placement[i] = clone.placement[j];
 					clone.placement[j] = temp;
+					
+					var tempRotation = clone.rotation[i]; 
+					clone.rotation[i] = clone.rotation[j]; 
+					clone.rotation[j] = tempRotation ;
 				}
 			}
 			


### PR DESCRIPTION
Here is the current `mutate` function:
https://github.com/Jack000/SVGnest/blob/1248dc21efd3f90d1aa52ba5785e27e5217ed2c9/svgnest.js#L872-L894

When `clone.placement[i]` and `clone.placement[i]` are swapped to create an order mutation, I think maybe it is better to also swap the `clone.rotation` . 

For example, if there are two 2 parts called `A` and `B`. To put A in the bin, `A` can not be rotated by `90` degree while `B` can do this. 

![Demo](https://user-images.githubusercontent.com/11558955/117647522-a3ce2c80-b1bf-11eb-99bd-026fbe4268f4.png)

This means, the value of `clone.rotation[j]`(`B`) can be `90` while the value of `clone.rotation[i]`(`A`) is `0`. 
In this case,  if `clone.placement[i]` and `clone.placement[j]` are swapped, and `clone.rotation[i]` or `clone.rotation[j]` happens not to be regenerated by `this.randomAngle(clone.placement[i])` later, then it would produce an unexpected mutation result.

Although this issue will not happen to small parts data input, I think this change make it more reasonable for big parts input.

Here is the SVG input example [mutationExample.zip](https://github.com/Jack000/SVGnest/files/6451538/mutationExample.zip), if needed, it can be used for test. 
