### PR TITLE
Provide Dockerfile for local/self-hosted running of the tool.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+*.md
+License.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:stable-alpine
+
+COPY . /usr/share/nginx/html/

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,18 @@ Performs similarly to commercial software, after both have run for about 5 minut
 
 ![Concave flag example](http://svgnest.com/github/concave.png)
 
+## Run with Docker
+
+A Dockerfile has been provided for those wanting to run locally/self-host with [Docker](https://www.docker.com/).
+Build/run commands provided below:
+
+```bash
+docker build -t svgnest .
+docker run -d --name svgnest -p 8080:80 svgnest
+```
+
+The instance is then available by navigating to http://localhost:8080.
+
 ## To-do
 
 - ~~Recursive placement (putting parts in holes of other parts)~~


### PR DESCRIPTION
Added dockerfile to resolve #116. Tested on Ubuntu WSL and in a micro8s kubernetes cluster. Added a section at the bottom of the readme.md to give some basic launch instructions.